### PR TITLE
fix: load homebrew after install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -37,6 +37,10 @@ then
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
+echo '# Set PATH, MANPATH, etc., for Homebrew.' >> /Users/${USER}/.zprofile
+echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/${USER}/.zprofile
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # Update brew
 brew update
 


### PR DESCRIPTION
The script currently skips everything after `brew update` as brew is not recognised. To mitigate that, add it to the user's `.zprofile` and load it manually