### PR TITLE
fix: add python3.9 to packages

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -59,6 +59,7 @@ PACKAGES=(
   nvm
   python
   python3
+  python@3.9
   tree
   vim
   wget


### PR DESCRIPTION
python3.9 is required to build node 14.17 - which doesn't seem to have a published arm64 package